### PR TITLE
feat: add AssetIndexed / AssetFailed terminal events (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- **Terminal ingestion events** — new `AssetIndexed` and `AssetFailed` events fired after `Ingestion::markState()` reaches a terminal state. Unlike `IngestionStateChanged` they are dispatched via `dispatch()->afterResponse()` in a web request, so listeners run after the caller has committed its outer transaction and linked its domain rows to the asset. In CLI/queue-worker contexts they fire immediately (no response boundary to defer against). Eliminates the race condition where consumers had to fall back to matching assets by `source_name` because listeners ran before `ai_asset_id` was stored. `IngestionStateChanged` behavior is unchanged — fully backward compatible. (#5)
+
 ## v0.2.2 - 2026-04-18
 
 ### Fixed

--- a/docs/ingestion-pipeline.md
+++ b/docs/ingestion-pipeline.md
@@ -58,7 +58,19 @@ Each ingestion is tracked in the `ai_ingestions` table:
 | `indexed` | Complete — chunks are searchable |
 | `failed` | Error occurred (check `error` column) |
 
-An `IngestionStateChanged` event is fired on every state transition. Listen to it for monitoring:
+## Pipeline Events
+
+Three events let you hook into the pipeline. Pick the one that matches your use case:
+
+| Event | When it fires | Timing | Use it for |
+|---|---|---|---|
+| `IngestionStateChanged` | Every state transition | Immediate | Progress bars, live status |
+| `AssetIndexed` | State reaches `indexed` | Deferred (`afterResponse`) | Post-ingest business logic |
+| `AssetFailed` | State reaches `failed` | Deferred (`afterResponse`) | Alerts, retries |
+
+### `IngestionStateChanged` — all transitions, immediate
+
+Fires on every state change. Good for progress tracking and logging:
 
 ```php
 use LarAIgent\AiKit\Events\IngestionStateChanged;
@@ -69,6 +81,40 @@ Event::listen(IngestionStateChanged::class, function ($event) {
     ]);
 });
 ```
+
+### `AssetIndexed` / `AssetFailed` — terminal, deferred
+
+Fire only on the terminal states, and are dispatched via `afterResponse()` in
+a web request. That means listeners run **after** your controller returns and
+your outer DB transaction commits — you can safely look up the asset by the
+foreign key you just stored:
+
+```php
+use LarAIgent\AiKit\Events\AssetIndexed;
+use LarAIgent\AiKit\Events\AssetFailed;
+
+Event::listen(AssetIndexed::class, function ($event) {
+    // By the time this runs, the caller has committed.
+    // You can safely find your domain row by ai_asset_id.
+    KnowledgeBase::where('ai_asset_id', $event->asset->id)->update([
+        'status' => 'indexed',
+        'chunk_count' => $event->ingestion->chunk_count,
+        'indexed_at' => now(),
+    ]);
+});
+
+Event::listen(AssetFailed::class, function ($event) {
+    Mail::to(config('alerts.ingestion'))
+        ->send(new IngestionFailedMail($event->asset, $event->error));
+});
+```
+
+In CLI or queue-worker contexts (no HTTP response boundary), these fire
+immediately — still correct because the job has already completed.
+
+**Prefer the terminal events when you only care about "did it work."** They
+eliminate the race where a listener fires before the caller has linked the
+asset ID to its own rows.
 
 ## Safety: Zero-Chunk Guard
 

--- a/src/Events/AssetFailed.php
+++ b/src/Events/AssetFailed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LarAIgent\AiKit\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use LarAIgent\AiKit\Models\Asset;
+use LarAIgent\AiKit\Models\Ingestion;
+
+/**
+ * Fired after an asset's pipeline terminates with state = "failed".
+ *
+ * Deferred via `afterResponse()` in a web request so listeners run after the
+ * caller has committed. In CLI / queue-worker contexts it's equivalent to
+ * immediate dispatch.
+ *
+ * Prefer this over `IngestionStateChanged` when you only need to know about
+ * terminal failures (for alerts, user notifications, retry logic).
+ */
+class AssetFailed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Asset $asset,
+        public readonly Ingestion $ingestion,
+        public readonly string $error,
+    ) {}
+}

--- a/src/Events/AssetIndexed.php
+++ b/src/Events/AssetIndexed.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LarAIgent\AiKit\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use LarAIgent\AiKit\Models\Asset;
+use LarAIgent\AiKit\Models\Ingestion;
+
+/**
+ * Fired after an asset's pipeline completes successfully (state = "indexed").
+ *
+ * Unlike `IngestionStateChanged`, this event is deferred via `afterResponse()`
+ * in a web request, so listeners run after the caller has committed its outer
+ * DB transaction and stored `$asset->id` against their own domain rows.
+ *
+ * In CLI / queue-worker contexts, `afterResponse()` degrades to immediate
+ * dispatch — which is still correct because the worker has finished its job
+ * by the time the event fires.
+ *
+ * Prefer this over `IngestionStateChanged` if all you care about is
+ * "this asset is now searchable."
+ */
+class AssetIndexed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Asset $asset,
+        public readonly Ingestion $ingestion,
+    ) {}
+}

--- a/src/Models/Ingestion.php
+++ b/src/Models/Ingestion.php
@@ -4,6 +4,9 @@ namespace LarAIgent\AiKit\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\App;
+use LarAIgent\AiKit\Events\AssetFailed;
+use LarAIgent\AiKit\Events\AssetIndexed;
 use LarAIgent\AiKit\Events\IngestionStateChanged;
 
 class Ingestion extends Model
@@ -54,12 +57,36 @@ class Ingestion extends Model
             'error' => $error,
         ]);
 
-        // Fire event for pipeline observability
-        IngestionStateChanged::dispatch(
-            $this->asset ?? $this->asset()->first(),
-            $this,
-            $state,
-            $error,
-        );
+        $asset = $this->asset ?? $this->asset()->first();
+
+        // Fire immediate lifecycle event for progress tracking
+        IngestionStateChanged::dispatch($asset, $this, $state, $error);
+
+        // Fire terminal events deferred — listeners run after the caller has
+        // committed its outer transaction and linked its domain rows to the
+        // asset. In CLI/queue contexts this degrades to immediate dispatch.
+        if ($state === 'indexed') {
+            $this->dispatchTerminal(fn () => AssetIndexed::dispatch($asset, $this));
+        } elseif ($state === 'failed') {
+            $this->dispatchTerminal(
+                fn () => AssetFailed::dispatch($asset, $this, $error ?? 'unknown error'),
+            );
+        }
+    }
+
+    /**
+     * Dispatch a terminal event after the response is sent when running in a
+     * web request. Outside of HTTP (CLI, queue worker, tests), dispatch
+     * immediately since there is no response boundary to wait for.
+     */
+    protected function dispatchTerminal(callable $dispatcher): void
+    {
+        if (App::runningInConsole()) {
+            $dispatcher();
+
+            return;
+        }
+
+        dispatch($dispatcher)->afterResponse();
     }
 }


### PR DESCRIPTION
Adds two new events that fire only when the ingestion pipeline reaches a terminal state, dispatched via dispatch()->afterResponse() in a web request so listeners run after the caller has committed its outer transaction.

- AssetIndexed: fires when state = "indexed"
- AssetFailed: fires when state = "failed" (carries $error)

In CLI / queue-worker contexts they fire immediately since there is no response boundary to defer against — still correct because the worker has completed the job by that point.

IngestionStateChanged behavior is unchanged. The new events are opt-in and fully backward compatible — consumers only subscribe if they want them.

Closes #5